### PR TITLE
Issue RotherOSS/otobo#417: rename otobo_cron_1 to otobo_daemon_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The user can control the workings of Docker Compose via the file _.env_.
 
 OTOBO webserver on internal port 5000.
 
-* Container otobo_cron_1
+* Container otobo_daemon_1
 
-The OTOBO daemon. A cronjob checks restarts the daemon in case of failures.
+The OTOBO daemon. There is a check that restarts the daemon when it has failed.
 
 * Container otobo_db_1
 
@@ -40,7 +40,7 @@ Volumes are created on the host in order to allow for persistent dats.
 These allow starting and stopping the services without loosing data. Keep in mind that
 containers are ephemeral and only the data in the volumes is for keeps.
 
-* **otobo_opt_otobo** containing `/opt/otobo` on the container `web` and `cron`.
+* **otobo_opt_otobo** containing `/opt/otobo` on the container `web` and `daemon`.
 * **otobo_mariadb_data** containing `/var/lib/mysql` on the container `db`.
 * **otobo_elasticsearch_data** containing `/usr/share/elasticsearch/datal` on the container `elastic`.
 * **otobo_redis_data** containing data on the container `redis`.
@@ -120,7 +120,7 @@ Example setting:
 
 * OTOBO_IMAGE_OTOBO
 
-Override the image used for running the Docker containers **otobo_web_1** and **otobo_cron_1**.
+Override the image used for running the Docker containers **otobo_web_1** and **otobo_daemon_1**.
 This is useful for running locally built images. Or for running images with additional features like
 access to other database systems.
 

--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -35,7 +35,7 @@ services:
 #    build:
 #      context: ../..
 #      dockerfile: otobo.web.dockerfile
-    # give a name to the built image so that the service 'cron' can reuse it
+    # give a name to the built image so that the service 'daemon' can reuse it
     image: ${OTOBO_IMAGE_OTOBO:-rotheross/otobo:latest}
     depends_on:
       - db
@@ -50,14 +50,14 @@ services:
       - opt_otobo:/opt/otobo
     command: web
 
-  cron:
+  daemon:
     image: ${OTOBO_IMAGE_OTOBO:-rotheross/otobo:latest}
     depends_on:
       - web
     restart: always
     volumes:
       - opt_otobo:/opt/otobo
-    command: cron
+    command: daemon
 
   # a container running Elasticsearch
   elastic:


### PR DESCRIPTION
As cron is no longer used.