### PR TITLE
Issue RotherOSS/otobo#417: rename service 'cron' to 'daemon'

### DIFF
--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -30,12 +30,9 @@ services:
       MYSQL_ROOT_PASSWORD: ${OTOBO_DB_ROOT_PASSWORD:?err}
     command: --max-allowed-packet=68157440 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-log-file-size=268435456
 
+  # a container running a webserver
   web:
-#    # use ./Dockerfile for building, image otobo_web
-#    build:
-#      context: ../..
-#      dockerfile: otobo.web.dockerfile
-    # give a name to the built image so that the service 'cron' can reuse it
+    # The services 'web' and 'daemon' use the same image.
     image: ${OTOBO_IMAGE_OTOBO:-rotheross/otobo:latest}
     depends_on:
       - db
@@ -50,13 +47,16 @@ services:
       - opt_otobo:/opt/otobo
     command: web
 
-  cron:
+  # a container running the OTOBO daemon
+  daemon:
+    # The services 'web' and 'daemon' use the same image.
     image: ${OTOBO_IMAGE_OTOBO:-rotheross/otobo:latest}
     depends_on:
       - web
     restart: always
     volumes:
       - opt_otobo:/opt/otobo
+    # NOTE: the command will change in OTOBO 10.0.4
     command: cron
 
   # a container running Elasticsearch


### PR DESCRIPTION
Even though the command 'cron' is still running in the container.