### PR TITLE
Issue RotherOSS/otobo#514: add sample settings

### DIFF
--- a/.docker_compose_env_https
+++ b/.docker_compose_env_https
@@ -16,7 +16,11 @@ OTOBO_DB_ROOT_PASSWORD=
 # HTTPS options
 # set OTOBO_WEB_HTTPS_PORT when the HTTPS port is not 443
 #OTOBO_WEB_HTTPS_PORT=<your special port>
-# OTOBO_NGINX_SSL_CERTIFICATE and OTOBO_NGINX_SSL_CERTIFICATE_KEY are required
+# The settings OTOBO_NGINX_SSL_CERTIFICATE and OTOBO_NGINX_SSL_CERTIFICATE_KEY
+# are mandatory when HTTPS is used.
+# The configured pathes must be absolute pathes that are available in the container.
+#OTOBO_NGINX_SSL_CERTIFICATE=/etc/nginx/ssl/ssl-cert.crt
+#OTOBO_NGINX_SSL_CERTIFICATE_KEY=/etc/nginx/ssl/ssl-key.key
 OTOBO_NGINX_SSL_CERTIFICATE=
 OTOBO_NGINX_SSL_CERTIFICATE_KEY=
 


### PR DESCRIPTION
specifically for
OTOBO_NGINX_SSL_CERTIFICATE=/etc/nginx/ssl/ssl-cert.crt
and
OTOBO_NGINX_SSL_CERTIFICATE_KEY=/etc/nginx/ssl/ssl-key.key