### PR TITLE
Issue rotheross/otobo#682: Mount /opt/otobo

### DIFF
--- a/docker-compose/otobo-selenium.yml
+++ b/docker-compose/otobo-selenium.yml
@@ -21,5 +21,9 @@ services:
     restart: always
     volumes:
       - /dev/shm:/dev/shm
+      - opt_otobo:/opt/otobo
     ports:
       - "${OTOBO_SELENIUM_VNC_CHROME:-5900}:5900"
+
+volumes:
+  opt_otobo: {}


### PR DESCRIPTION
Because the sample files are needed where the browser runs.