### PR TITLE
Issue #30 MariaDB query cache size

### DIFF
--- a/.docker_compose_env_http
+++ b/.docker_compose_env_http
@@ -8,6 +8,9 @@ COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-http.ym
 # OTOBO_DB_ROOT_PASSWORD must be set
 OTOBO_DB_ROOT_PASSWORD=
 
+# Set this to a value in bytes to overwrite the default query size set for OTOBO
+#OTOBO_DB_QUERY_CACHE_SIZE=
+
 # HTTP options
 # Set OTOBO_WEB_HTTP_PORT when the HTTP port is not 80
 #OTOBO_WEB_HTTP_PORT=<your special port>

--- a/.docker_compose_env_http_selenium
+++ b/.docker_compose_env_http_selenium
@@ -8,6 +8,9 @@ COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-http.ym
 # OTOBO_DB_ROOT_PASSWORD must be set
 OTOBO_DB_ROOT_PASSWORD=
 
+# Set this to a value in bytes to overwrite the default query size set for OTOBO
+#OTOBO_DB_QUERY_CACHE_SIZE=
+
 # HTTP options
 # Set OTOBO_WEB_HTTP_PORT when the HTTP port is not 80
 #OTOBO_WEB_HTTP_PORT=<your special port>

--- a/.docker_compose_env_https
+++ b/.docker_compose_env_https
@@ -8,6 +8,9 @@ COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https.y
 # OTOBO_DB_ROOT_PASSWORD must be set
 OTOBO_DB_ROOT_PASSWORD=
 
+# Set this to a value in bytes to overwrite the default query size set for OTOBO
+#OTOBO_DB_QUERY_CACHE_SIZE=
+
 # HTTP options
 # In the HTTPS case http:// redirects to https://
 # Set OTOBO_WEB_HTTP_PORT when the HTTP port is not 80

--- a/.docker_compose_env_https_custom_nginx
+++ b/.docker_compose_env_https_custom_nginx
@@ -8,6 +8,9 @@ COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https.y
 # OTOBO_DB_ROOT_PASSWORD must be set
 OTOBO_DB_ROOT_PASSWORD=
 
+# Set this to a value in bytes to overwrite the default query size set for OTOBO
+#OTOBO_DB_QUERY_CACHE_SIZE=
+
 # HTTP options
 # In the HTTPS case http:// redirects to https://
 # Set OTOBO_WEB_HTTP_PORT when the HTTP port is not 80

--- a/.docker_compose_env_https_kerberos
+++ b/.docker_compose_env_https_kerberos
@@ -8,6 +8,9 @@ COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https-k
 # OTOBO_DB_ROOT_PASSWORD must be set
 OTOBO_DB_ROOT_PASSWORD=
 
+# Set this to a value in bytes to overwrite the default query size set for OTOBO
+#OTOBO_DB_QUERY_CACHE_SIZE=
+
 # HTTP options
 # In the HTTPS case http:// redirects to https://
 # Set OTOBO_WEB_HTTP_PORT when the HTTP port is not 80

--- a/.docker_compose_env_https_selenium
+++ b/.docker_compose_env_https_selenium
@@ -8,6 +8,9 @@ COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https.y
 # OTOBO_DB_ROOT_PASSWORD must be set
 OTOBO_DB_ROOT_PASSWORD=
 
+# Set this to a value in bytes to overwrite the default query size set for OTOBO
+#OTOBO_DB_QUERY_CACHE_SIZE=
+
 # HTTP options
 # In the HTTPS case http:// redirects to https://
 # Set OTOBO_WEB_HTTP_PORT when the HTTP port is not 80

--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -34,7 +34,7 @@ services:
     # OTOBO_DB_ROOT_PASSWORD=otobo_root
     environment:
       MYSQL_ROOT_PASSWORD: ${OTOBO_DB_ROOT_PASSWORD:?err}
-    command: --max-allowed-packet=68157440 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-log-file-size=268435456
+    command: --max-allowed-packet=68157440 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-log-file-size=268435456 --query-cache-size=${OTOBO_DB_QUERY_CACHE_SIZE:-33554432}
 
   # a container running a webserver
   web:


### PR DESCRIPTION
This change sets the query cache size to 33554432 if not specified otherwise in .env.

In the following picture I checked the query size variable in the DB right after creating the database via installer.pl
![image](https://user-images.githubusercontent.com/87969604/130600570-2362aaa9-b2c9-4bf4-9b41-0f236e4e1608.png)
