### PR TITLE
Add NGINX_ENVSUBST_TEMPLATE_DIR to dummy env file

### DIFF
--- a/.docker_compose_env_https_kerberos
+++ b/.docker_compose_env_https_kerberos
@@ -53,6 +53,9 @@ OTOBO_NGINX_KERBEROS_ADMIN_SERVER=rother-oss.com
 # Kerberos Default Domain
 OTOBO_NGINX_KERBEROS_DEFAULT_DOMAIN=rother-oss.com
 
+# Kerberos Substitute Template Directory
+NGINX_ENVSUBST_TEMPLATE_DIR=
+
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 


### PR DESCRIPTION
NGINX_ENVSUBST_TEMPLATE_DIR was only referenced in otobo-override-https-kerberos.yml
Found while debugging #81 

Maybe we shoud add some hint to the comments on how to use this parameter.