### PR TITLE
Issue otobo#1912: no longer use OTOBO_SYNC_WITH_S3

### DIFF
--- a/.docker_compose_env_http
+++ b/.docker_compose_env_http
@@ -26,10 +26,6 @@ OTOBO_DB_ROOT_PASSWORD=
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 
-# Special configuration when running OTOBO in a cluster
-OTOBO_SYNC_WITH_S3=0
-#OTOBO_SYNC_WITH_S3=1
-
 ################################################################################
 # The Docker image for the service 'db' can be specified explicitly.
 # The default is mariadb:10.5

--- a/.docker_compose_env_http_selenium
+++ b/.docker_compose_env_http_selenium
@@ -26,10 +26,6 @@ OTOBO_DB_ROOT_PASSWORD=
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 
-# Special configuration when running OTOBO in a cluster
-OTOBO_SYNC_WITH_S3=0
-#OTOBO_SYNC_WITH_S3=1
-
 ################################################################################
 # The Docker image for the service 'db' can be specified explicitly.
 # The default is mariadb:10.5

--- a/.docker_compose_env_https
+++ b/.docker_compose_env_https
@@ -44,10 +44,6 @@ OTOBO_NGINX_SSL_CERTIFICATE_KEY=
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 
-# Special configuration when running OTOBO in a cluster
-OTOBO_SYNC_WITH_S3=0
-#OTOBO_SYNC_WITH_S3=1
-
 ################################################################################
 # The Docker image for the service 'db' can be specified explicitly.
 # The default is mariadb:10.5

--- a/.docker_compose_env_https_custom_nginx
+++ b/.docker_compose_env_https_custom_nginx
@@ -44,10 +44,6 @@ OTOBO_NGINX_SSL_CERTIFICATE_KEY=
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 
-# Special configuration when running OTOBO in a cluster
-OTOBO_SYNC_WITH_S3=0
-#OTOBO_SYNC_WITH_S3=1
-
 ################################################################################
 # The Docker image for the service 'db' can be specified explicitly.
 # The default is mariadb:10.5

--- a/.docker_compose_env_https_kerberos
+++ b/.docker_compose_env_https_kerberos
@@ -70,10 +70,6 @@ NGINX_ENVSUBST_TEMPLATE_DIR=
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 
-# Special configuration when running OTOBO in a cluster
-OTOBO_SYNC_WITH_S3=0
-#OTOBO_SYNC_WITH_S3=1
-
 ################################################################################
 # The Docker image for the service 'db' can be specified explicitly.
 # The default is mariadb:10.5

--- a/.docker_compose_env_https_selenium
+++ b/.docker_compose_env_https_selenium
@@ -44,10 +44,6 @@ OTOBO_NGINX_SSL_CERTIFICATE_KEY=
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 
-# Special configuration when running OTOBO in a cluster
-OTOBO_SYNC_WITH_S3=0
-#OTOBO_SYNC_WITH_S3=1
-
 ################################################################################
 # The Docker image for the service 'db' can be specified explicitly.
 # The default is mariadb:10.5

--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -67,8 +67,6 @@ services:
     #    - "80:5000"
     volumes:
       - opt_otobo:/opt/otobo
-    environment:
-      OTOBO_SYNC_WITH_S3: ${OTOBO_SYNC_WITH_S3:-0}
     command: web
     healthcheck:
       test: curl -s -f http://localhost:5000/otobo/index.pl
@@ -85,8 +83,6 @@ services:
     restart: always
     volumes:
       - opt_otobo:/opt/otobo
-    environment:
-      OTOBO_SYNC_WITH_S3: ${OTOBO_SYNC_WITH_S3:-0}
     command: daemon
     healthcheck:
       test: ./bin/otobo.Daemon.pl status | grep 'Daemon running'

--- a/etc/templates/dot_env.m4
+++ b/etc/templates/dot_env.m4
@@ -151,10 +151,6 @@ m4_ifdef( `otoflag_KERBEROS', `', `m4_divert(0)')m4_dnl
 # Elasticsearch options
 OTOBO_ELASTICSEARCH_ES_JAVA_OPTS=-Xms512m -Xmx512m
 
-# Special configuration when running OTOBO in a cluster
-OTOBO_SYNC_WITH_S3=0
-#OTOBO_SYNC_WITH_S3=1
-
 ################################################################################
 # The Docker image for the service 'db' can be specified explicitly.
 # The default is mariadb:10.5


### PR DESCRIPTION
That environment variable is no longer used in OTOBO 10.1.6