### PR TITLE
Issue #113: declare the volume that is used in the Dockerfile

### DIFF
--- a/docker-compose/otobo-minio.yml
+++ b/docker-compose/otobo-minio.yml
@@ -20,9 +20,9 @@ services:
       - "9001:9001"
     restart: always
     volumes:
-      - tmp_minio:/tmp/minio
+      - minio_data:/data
     command: server --console-address ":9001" /data
 
 # no volumes need to be exposed across services
 volumes:
-  tmp_minio: {}
+  minio_data: {}


### PR DESCRIPTION
This is, replace tmp_minio:/tmp/minio by minio_data:/data