### PR TITLE
Issue #128: remove the version declaration

### DIFF
--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -5,9 +5,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   # the database

--- a/docker-compose/otobo-localstack.yml
+++ b/docker-compose/otobo-localstack.yml
@@ -6,9 +6,6 @@
 # See also README.md .
 # See also https://hub.docker.com/r/localstack/localstack .
 
-# same version as in otobo-base.yml
-version: '3.3'
-
 services:
 
   localstack:

--- a/docker-compose/otobo-nginx-custom-config.yml
+++ b/docker-compose/otobo-nginx-custom-config.yml
@@ -2,8 +2,6 @@
 
 # See also README.md.
 
-version: '3.3'
-
 services:
   nginx:
     volumes:

--- a/docker-compose/otobo-override-http.yml
+++ b/docker-compose/otobo-override-http.yml
@@ -3,9 +3,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   web:

--- a/docker-compose/otobo-override-https-kerberos.yml
+++ b/docker-compose/otobo-override-https-kerberos.yml
@@ -4,9 +4,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   # There is no HTTP port is specified, as the otobo webserver should only be reachable via HTTPS.

--- a/docker-compose/otobo-override-https.yml
+++ b/docker-compose/otobo-override-https.yml
@@ -4,9 +4,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   # There is no HTTP port is specified, as the otobo webserver should only be reachable via HTTPS.

--- a/docker-compose/otobo-selenium.yml
+++ b/docker-compose/otobo-selenium.yml
@@ -3,9 +3,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   selenium-chrome:


### PR DESCRIPTION
The 'version' was never used by Docker compose.
Since Docker 25.0 the following warning was emitted:
   version is obsolete
This warning is eliminated by removing the version declaration.