### PR TITLE
Remove redis snapshots and update redis to 8-alpine

### DIFF
--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -127,7 +127,7 @@ services:
 
   # a container running Redis
   redis:
-    image: ${OTOBO_IMAGE_REDIS:-redis:6.0-alpine}
+    image: ${OTOBO_IMAGE_REDIS:-redis:8-alpine}
     user: redis:redis
     cap_drop:
         - ALL
@@ -139,9 +139,10 @@ services:
             max-file: "5"
             max-size: "10m"
     volumes:
-      - redis_data:/data
+      - ../etc/redis:/data
     healthcheck:
       test: redis-cli ping
+    command: [ "redis-server", "/data/redis.conf" ]
 
 
 # no volumes need to be exposed across services
@@ -149,4 +150,3 @@ volumes:
   mariadb_data: {}
   opt_otobo: {}
   elasticsearch_data: {}
-  redis_data: {}

--- a/etc/redis/redis.conf
+++ b/etc/redis/redis.conf
@@ -1,0 +1,2 @@
+#Disable RDB Snapshots
+save ""


### PR DESCRIPTION
This pull request contains several changes:

- Updating redis from `6.0-alpine` to `8.alpine`
- Moving the `/data` directory mount for the redis container to `otobo-docker/etc/redis` (`/redis.conf`)
- Removing unnecessary redis namespace volume in compose file because volume is only needed for the config file
- Disabling automatic redis database snaphots using a custom `redis.conf`

All new implemented features got tested on an existing otobo 11.0.x installation using the steps from [Updating a Docker-based Installation of OTOBO](https://doc.otobo.de/manual/installation/11.0/en/content/updating-docker.html)