### PR TITLE
Set redis conf via cli

### DIFF
--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -146,11 +146,9 @@ services:
         options:
             max-file: "5"
             max-size: "10m"
-    volumes:
-      - ../etc/redis:/data
     healthcheck:
       test: redis-cli ping
-    command: [ "redis-server", "/data/redis.conf" ]
+    command: ["redis-server", "--save", ""]
 
 
 # no volumes need to be exposed across services

--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -148,7 +148,7 @@ services:
             max-size: "10m"
     healthcheck:
       test: redis-cli ping
-    command: ["redis-server", "--save", ""]
+    command: [ "redis-server", "--save", "" ]
 
 
 # no volumes need to be exposed across services

--- a/etc/redis/redis.conf
+++ b/etc/redis/redis.conf
@@ -1,2 +1,0 @@
-#Disable RDB Snapshots
-save ""


### PR DESCRIPTION
Refering to requested changes on #159.

- Disable automatic redis database snapshots using the `--save ""` argument in cli
- Remove unused redis.conf directory (`etc/redis/redis.conf`) and volume mount in `otobo-base.yml` because no more files need to be shared across hosts

All changes are tested on a existing 11.0.x otobo installation.