### PR TITLE
Update otobo-base.yml

### DIFF
--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -129,7 +129,7 @@ services:
     environment:
       discovery.type: single-node
       # allow access via HTTP and without login
-      xpack.security.enabled: false
+      xpack.security.enabled: "0"
       ES_JAVA_OPTS: ${OTOBO_ELASTICSEARCH_ES_JAVA_OPTS:?err}
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data


### PR DESCRIPTION
Error performing update script: "services.elastic.environment.xpack.security.enabled contains false, which is an invalid type, it should be a string, number, or a null" is thrown and update aborted.