### PR TITLE
Issue #128: remove the 'version' declaration

### DIFF
--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -5,9 +5,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   # the database

--- a/docker-compose/otobo-localstack.yml
+++ b/docker-compose/otobo-localstack.yml
@@ -6,9 +6,6 @@
 # See also README.md .
 # See also https://hub.docker.com/r/localstack/localstack .
 
-# same version as in otobo-base.yml
-version: '3.3'
-
 services:
 
   localstack:

--- a/docker-compose/otobo-minio.yml
+++ b/docker-compose/otobo-minio.yml
@@ -7,9 +7,6 @@
 # See also https://hub.docker.com/r/localstack/localstack .
 # Ses also https://docs.min.io/docs/deploy-minio-on-docker-compose.html
 
-# same version as in otobo-base.yml
-version: '3.3'
-
 services:
 
   minio:

--- a/docker-compose/otobo-nginx-custom-config.yml
+++ b/docker-compose/otobo-nginx-custom-config.yml
@@ -2,8 +2,6 @@
 
 # See also README.md.
 
-version: '3.3'
-
 services:
   nginx:
     volumes:

--- a/docker-compose/otobo-override-http.yml
+++ b/docker-compose/otobo-override-http.yml
@@ -3,9 +3,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   web:

--- a/docker-compose/otobo-override-https-kerberos.yml
+++ b/docker-compose/otobo-override-https-kerberos.yml
@@ -4,9 +4,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   # There is no HTTP port is specified, as the otobo webserver should only be reachable via HTTPS.

--- a/docker-compose/otobo-override-https.yml
+++ b/docker-compose/otobo-override-https.yml
@@ -4,9 +4,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   # There is no HTTP port is specified, as the otobo webserver should only be reachable via HTTPS.

--- a/docker-compose/otobo-selenium.yml
+++ b/docker-compose/otobo-selenium.yml
@@ -3,9 +3,6 @@
 
 # See also README.md.
 
-# most current docker-compose file version, as of 2020-05-21
-version: '3.3'
-
 services:
 
   selenium-chrome:


### PR DESCRIPTION
This declaration was only required by some versions of Docker Compose V1. But V1 is no longer supported. Removing the declaration eliminates warnings emitted by Docker Compose V2.