### PR TITLE
Issue #192: tentatively add override file for MySQL

### DIFF
--- a/.docker_compose_env_http
+++ b/.docker_compose_env_http
@@ -24,6 +24,7 @@ COMPOSE_PROJECT_NAME=otobo
 # Developers may use experimental override files.
 # - add OpenLDAP server for use by the unit tests:      :docker-compose/testing/openldap.yml
 # - replace MariaDB with PostgreSQL:                    :docker-compose/testing/postgresql.yml
+# - replace MariaDB with MySQL:                         :docker-compose/testing/mysql.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-http.yml
 

--- a/.docker_compose_env_http_selenium
+++ b/.docker_compose_env_http_selenium
@@ -24,6 +24,7 @@ COMPOSE_PROJECT_NAME=otobo
 # Developers may use experimental override files.
 # - add OpenLDAP server for use by the unit tests:      :docker-compose/testing/openldap.yml
 # - replace MariaDB with PostgreSQL:                    :docker-compose/testing/postgresql.yml
+# - replace MariaDB with MySQL:                         :docker-compose/testing/mysql.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-http.yml:docker-compose/otobo-selenium.yml
 

--- a/.docker_compose_env_https
+++ b/.docker_compose_env_https
@@ -24,6 +24,7 @@ COMPOSE_PROJECT_NAME=otobo
 # Developers may use experimental override files.
 # - add OpenLDAP server for use by the unit tests:      :docker-compose/testing/openldap.yml
 # - replace MariaDB with PostgreSQL:                    :docker-compose/testing/postgresql.yml
+# - replace MariaDB with MySQL:                         :docker-compose/testing/mysql.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https.yml
 

--- a/.docker_compose_env_https_custom_nginx
+++ b/.docker_compose_env_https_custom_nginx
@@ -24,6 +24,7 @@ COMPOSE_PROJECT_NAME=otobo
 # Developers may use experimental override files.
 # - add OpenLDAP server for use by the unit tests:      :docker-compose/testing/openldap.yml
 # - replace MariaDB with PostgreSQL:                    :docker-compose/testing/postgresql.yml
+# - replace MariaDB with MySQL:                         :docker-compose/testing/mysql.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https.yml:docker-compose/otobo-nginx-custom-config.yml
 

--- a/.docker_compose_env_https_kerberos
+++ b/.docker_compose_env_https_kerberos
@@ -24,6 +24,7 @@ COMPOSE_PROJECT_NAME=otobo
 # Developers may use experimental override files.
 # - add OpenLDAP server for use by the unit tests:      :docker-compose/testing/openldap.yml
 # - replace MariaDB with PostgreSQL:                    :docker-compose/testing/postgresql.yml
+# - replace MariaDB with MySQL:                         :docker-compose/testing/mysql.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https-kerberos.yml
 

--- a/.docker_compose_env_https_selenium
+++ b/.docker_compose_env_https_selenium
@@ -24,6 +24,7 @@ COMPOSE_PROJECT_NAME=otobo
 # Developers may use experimental override files.
 # - add OpenLDAP server for use by the unit tests:      :docker-compose/testing/openldap.yml
 # - replace MariaDB with PostgreSQL:                    :docker-compose/testing/postgresql.yml
+# - replace MariaDB with MySQL:                         :docker-compose/testing/mysql.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose/otobo-base.yml:docker-compose/otobo-override-https.yml:docker-compose/otobo-selenium.yml
 

--- a/docker-compose/testing/mysql.yml
+++ b/docker-compose/testing/mysql.yml
@@ -1,0 +1,43 @@
+# Experimental Docker compose override file the database PostgreSQL.
+
+services:
+
+  # the database server
+  db:
+    image: ${OTOBO_IMAGE_DB:-mysql:8.4}
+    #image: ${OTOBO_IMAGE_DB:-mysql:9.3}
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+    # Within the container network the MySQL server listens to its default port 3306.
+    # Per default this port is not exposed to the outside world.
+    # One can use 'docker-compose exec -it db mysql ...' when access to the database is needed.
+    # But for development it can be useful to expose the port 3306. E.g. when a graphical client
+    # like MySQL Workbench or DBeaver is used. Uncomment the following lines for making MariaDB available
+    # on port 3307 on the Docker host. A non-standard port is chosen here, because 3306 is
+    # often already used on the Docker host.
+    #
+    # Instead of changing the port here one can also use
+    # the the compose file docker-compose/otobo-override-db-exposed.yml
+    # ports:
+    #   - "3307:3306"
+
+    # The actual name of the database server executable is provided
+    # in the entrypoint of the Docker image.  Up to MariaDB 10.5 the server executable had been called 'mysqld'.
+    # Later versions use the executable 'mariadbd'.
+    command:
+      - --max-allowed-packet=136314880
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --innodb-log-file-size=268435456
+      # - --query-cache-size=${OTOBO_DB_QUERY_CACHE_SIZE:-33554432}   # MariaDB specific
+      - --mysql_native_password=on
+      #- --require-secure-transport
+      #- --auto-generate-certs
+
+    # The health check for MySQL is still to be determined.
+    healthcheck:
+      test: 'true'
+
+volumes:
+  mysql_data: {}

--- a/docker-compose/testing/postgresql.yml
+++ b/docker-compose/testing/postgresql.yml
@@ -1,9 +1,4 @@
-# Docker compose file for the OTOBO webapp.
-# Note that no port is exposed as both HTTP and HTTPS are supported.
-# For HTTP see the extension file docker-compose/otobo-override-http.yml.
-# For HTTPS see the extension file docker-compose/otobo-override-https.yml.
-
-# See also README.md.
+# Experimental Docker compose override file the database PostgreSQL.
 
 services:
 
@@ -43,8 +38,8 @@ services:
     command: []
 
     # The health check for PostgreSQL is still to be determined.
-    #healthcheck:
-    #  test: ["CMD-SHELL", "pg_isready"]
+    healthcheck:
+      test: 'true'
 
 volumes:
   postgresql_data: {}

--- a/etc/templates/dot_env.m4
+++ b/etc/templates/dot_env.m4
@@ -95,6 +95,7 @@ COMPOSE_PROJECT_NAME=otobo
 # Developers may use experimental override files.
 # - add OpenLDAP server for use by the unit tests:      :docker-compose/testing/openldap.yml
 # - replace MariaDB with PostgreSQL:                    :docker-compose/testing/postgresql.yml
+# - replace MariaDB with MySQL:                         :docker-compose/testing/mysql.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=otovar_COMPOSE_FILE
 


### PR DESCRIPTION
That new override file is only meant for development and testing.

Also update description of override file for PostgreSQL Also change the healthcheck for PostgreSQL to 'true' so that the MariaDB healthcheck is overridden