### PR TITLE
Issue #203: export db only to localhost on the Docker host

### DIFF
--- a/docker-compose/otobo-base.yml
+++ b/docker-compose/otobo-base.yml
@@ -29,13 +29,18 @@ services:
     # One can use 'docker-compose exec -it db mysql ...' when access to the database is needed.
     # But for development it can be useful to expose the port 3306. E.g. when a graphical client
     # like MySQL Workbench or DBeaver is used. Uncomment the following lines for making MariaDB available
-    # on port 3307 on the Docker host. A non-standard port is chosen here, because 3306 is
-    # often already used on the Docker host.
+    # on port 3307 on the Docker host. The non-standard port 3307 is chosen here, because the porr 3306
+    # is often already used on the Docker host.
+    #
+    # In this sample config the port is only exposed to localhost on the Docker host.
+    # The config must be adapted if the database should be reachable from other network interfaces.
+    # See https://github.com/compose-spec/compose-spec/blob/main/spec.md#ports .
     #
     # Instead of changing the port here one can also use
     # the the compose file docker-compose/otobo-override-db-exposed.yml
-    # ports:
-    #   - "3307:3306"
+    #
+    #ports:
+    #  - "127.0.0.1:3307:3306"
 
     # Set the db root password which has to be entered when running otobo/installer.pl.
     # The passwort is secret and can be stored in the file .env.


### PR DESCRIPTION
There is no functional change as only a commented out sample setting has been changed.