### PR TITLE
Issue #217: merge the LDAP sample from Mike Thumes

### DIFF
--- a/docker-compose/testing/openldap.yml
+++ b/docker-compose/testing/openldap.yml
@@ -1,42 +1,21 @@
-# Run a standalone container for OpenLDAP testing.
-
-# There is no persistent data
-
-# Can be activated by appending the path to this file to the setting COMPOSE_FILE
-# in the setup file .env.
-
-# The ports are exposed. On the Docker host the tree can be dumped with:
-
-# Examples for querying LDAP:
-
-#ldapsearch -x -b "dc=otobotesting" -H ldap://localhost:1389
-
-# check connectivity
-#ldapsearch -x -H ldap://localhost:1389 -b dc=otobotesting -D "dc=otobotesting" -w password
-
-# list all entries
-#ldapsearch -x -H ldap://localhost:1389 -b dc=otobotesting -s sub -D "cn=openldap_admin,dc=otobotesting" -w password '(objectClass=*)' +
-
-# show a group
-#ldapsearch -x -H ldap://localhost:1389 -b dc=otobotesting -s sub -D "cn=openldap_admin,dc=otobotesting" -w password '(cn=admins)' dn member
-
-# show a user
-#ldapsearch -x -H ldap://localhost:1389 -b dc=otobotesting -s sub -D "cn=openldap_admin,dc=otobotesting" -w password '(uid=testadmin)' uid memberOf
-
 services:
 
+  # Service for testing integration with LDAP
+  # See testing/openldap/README.md
   testing-openldap:
-    image: bitnamilegacy/openldap:latest
-    ports:
-      - 1389:1389
-      - 1636:1636
+    image: osixia/openldap:1.5.0
+    command: --copy-service --loglevel debug
     environment:
-      - LDAP_ADMIN_USERNAME=openldap_admin
-      - LDAP_ADMIN_PASSWORD=openldap_admin
-      - LDAP_USERS=otobotestuser1,otobotestuser2
-      - LDAP_PASSWORDS=otobotestuser1,otobotestuser2
-      - LDAP_ROOT=dc=otobotesting
-      - LDAP_USER_OU=agents
-      - LDAP_GROUP_OU=agent_groups
-      - LDAP_LOGLEVEL=any
-    restart: always
+      - LDAP_ORGANISATION=OTOBO Testing
+      - LDAP_DOMAIN=otobotesting
+      - LDAP_BASE_DN=dc=otobotesting
+      - LDAP_PORT=1389
+      - LDAP_ADMIN_PASSWORD=admin
+      - LDAP_RFC2307BIS_SCHEMA=true
+    ports:
+      - 389:389
+      - 636:636
+    volumes:
+
+      # bind mount relative to the directory docker-compose, but the logic is not obvious
+      - ../testing/openldap/data/bootstrap.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/bootstrap.ldif

--- a/testing/openldap/Config.pm.example
+++ b/testing/openldap/Config.pm.example
@@ -1,0 +1,120 @@
+    # ---------------------------------------------------- #
+    # insert your own config settings "here"               #
+    # config settings taken from Kernel/Config/Defaults.pm #
+    # ---------------------------------------------------- #
+
+    # This is an example configuration for an LDAP auth. backend.
+    # (take care that Net::LDAP is installed!)
+    $Self->{AuthModule1} = 'Kernel::System::Auth::LDAP';
+    $Self->{'AuthModule::LDAP::Host1'} = 'openldap';
+    $Self->{'AuthModule::LDAP::BaseDN1'} = 'dc=otobotesting';
+    $Self->{'AuthModule::LDAP::UID1'} = 'uid';
+
+    # Check if the user is allowed to auth in a posixGroup
+    # (e. g. user needs to be in a group xyz to use otobo)
+#    $Self->{'AuthModule::LDAP::GroupDN'} = 'cn=otoboallow,ou=posixGroups,dc=otobotesting';
+#    $Self->{'AuthModule::LDAP::AccessAttr'} = 'memberUid';
+    # for ldap posixGroups objectclass (just uid)
+#    $Self->{'AuthModule::LDAP::UserAttr'} = 'UID';
+    # for non ldap posixGroups objectclass (with full user dn)
+#    $Self->{'AuthModule::LDAP::UserAttr'} = 'DN';
+
+    # The following is valid but would only be necessary if the
+    # anonymous user do NOT have permission to read from the LDAP tree
+    $Self->{'AuthModule::LDAP::SearchUserDN1'} = 'cn=admin,dc=otobotesting';
+    $Self->{'AuthModule::LDAP::SearchUserPw1'} = 'admin';
+
+
+
+ # --------------------------------------------------- #
+    # authentication sync settings                        #
+    # (enable agent data sync. after succsessful          #
+    # authentication)                                     #
+    # --------------------------------------------------- #
+    # This is an example configuration for an LDAP auth sync. backend.
+    # (take care that Net::LDAP is installed!)
+    $Self->{AuthSyncModule1} = 'Kernel::System::Auth::Sync::LDAP';
+    $Self->{'AuthSyncModule::LDAP::Host1'} = 'openldap';
+    $Self->{'AuthSyncModule::LDAP::BaseDN1'} = 'dc=otobotesting';
+    $Self->{'AuthSyncModule::LDAP::UID1'} = 'uid';
+#    $Self->{'AuthSyncModule::LDAP::GroupDN1'} = 'cn=agents,ou=devops,dc=otobotesting';
+
+    # The following is valid but would only be necessary if the
+    # anonymous user do NOT have permission to read from the LDAP tree
+    $Self->{'AuthSyncModule::LDAP::SearchUserDN1'} = 'cn=admin,dc=otobotesting';
+    $Self->{'AuthSyncModule::LDAP::SearchUserPw1'} = 'admin';
+
+    # in case you want to add always one filter to each ldap query, use
+    # this option. e. g. AlwaysFilter => '(mail=*)' or AlwaysFilter => '(objectclass=user)'
+    # or if you want to filter with a logical OR-Expression, like AlwaysFilter => '(|(mail=*abc.com)(mail=*xyz.com))'
+#    $Self->{'AuthSyncModule::LDAP::AlwaysFilter'} = '';
+
+    # AuthSyncModule::LDAP::UserSyncMap
+    # (map if agent should create/synced from LDAP to DB after successful login)
+    # you may specify LDAP-Fields as either
+    #  * list, which will check each field. first existing will be picked ( ["givenName","cn","_empty"] )
+    #  * name of an LDAP-Field (may return empty strings) ("givenName")
+    #  * fixed strings, prefixed with an underscore: "_test", which will always return this fixed string
+    $Self->{'AuthSyncModule::LDAP::UserSyncMap1'} = {
+        # DB -> LDAP
+        UserFirstname => 'givenName',
+        UserLastname  => 'sn',
+        UserEmail     => 'mail',
+    };
+
+    # Net::LDAP new params (if needed - for more info see perldoc Net::LDAP)
+#    $Self->{'AuthSyncModule::LDAP::Params'} = {
+#        port    => 389,
+#        timeout => 120,
+#        async   => 0,
+#        version => 3,
+#    };
+    # Net::LDAP::start_tls verify type (if needed - for more info see Net::LDAP::start_tls)
+#    $Self->{'AuthSyncModule::LDAP::StartTLS'} = 'required';
+
+
+    # Die if backend can't work, e. g. can't connect to server.
+#    $Self->{'AuthSyncModule::LDAP::Die'} = 1;
+
+    # Attributes needed for group syncs
+    # (attribute name for group value key)
+    $Self->{'AuthSyncModule::LDAP::AccessAttr1'} = 'member';
+    # (attribute for type of group content UID/DN for full ldap name)
+    $Self->{'AuthSyncModule::LDAP::UserAttr'} = 'UID';
+#    $Self->{'AuthSyncModule::LDAP::UserAttr1'} = 'DN';
+
+    # AuthSyncModule::LDAP::UserSyncInitialGroups
+    # (sync following group with rw permission after initial create of first agent
+    # login)
+#    $Self->{'AuthSyncModule::LDAP::UserSyncInitialGroups1'} = [
+#        'users',
+#    ];
+
+    # Utilize extended nested group search?
+#    $Self->{'AuthSyncModule::LDAP::NestedGroupSearch'} = '1';
+
+    # AuthSyncModule::LDAP::UserSyncGroupsDefinition
+    # (If "LDAP" was selected for AuthModule and you want to sync LDAP
+    # groups to otobo groups, define the following.)
+   $Self->{'AuthSyncModule::LDAP::UserSyncGroupsDefinition1'} = {
+       # ldap group
+       'cn=admins,dc=otobotesting' => {
+           # otobo group
+           'admin' => {
+               # permission
+               rw => 1,
+               ro => 1,
+           },
+           'faq' => {
+               rw => 0,
+               ro => 1,
+           },
+       },
+       'cn=agents,dc=otobotesting' => {
+           'users' => {
+               rw => 1,
+               ro => 1,
+           },
+       }
+   };
+

--- a/testing/openldap/README.md
+++ b/testing/openldap/README.md
@@ -1,0 +1,33 @@
+# Basic container for testing LDAP integration in OTOBO
+
+- starts a container running LDAP within the otobo\_default network
+- the used Docker image is https://hub.docker.com/r/osixia/openldap
+- see testing/openldap/Config.pm.example for basic config
+- otobo auth works
+- user + role mapping works - see Config.pm.example for mapping
+- ldap is bootstraped from testing/openldap/data/bootstrap.ldif, add new users / groups there
+
+## OTOBO Config
+
+- add Config.pm.example content to Kernel/Config.pm
+- disable 'CheckEmailAddresses' in SysConfig, or change the testuser's email in testing/openldap/data/bootstrap.ldif
+
+## test credentials out of the box:
+
+### admin user
+
+username: testadmin
+pwd: testadmin
+
+### agent user
+
+username: testagent
+pwd: testagent
+
+## Inspect LDAP
+
+See the sample commands in testting/openldap/lds.
+
+
+
+

--- a/testing/openldap/data/bootstrap.ldif
+++ b/testing/openldap/data/bootstrap.ldif
@@ -1,0 +1,61 @@
+# example OU
+dn: ou=devops,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: organizationalUnit
+ou: devops
+
+# example admin user
+dn: cn=testadmin,ou=devops,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: inetOrgPerson
+givenName: Admin
+cn: testadmin
+sn: TestAdmin
+uid: testadmin
+mail: testadmin@{{ LDAP_DOMAIN }}
+preferredLanguage: en
+userPassword: testadmin
+
+# example agent user otobotestuser1
+dn: cn=otobotestuser1,ou=devops,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: inetOrgPerson
+givenName: User
+cn: otobotestuser1
+sn: TestAgent 1
+uid: otobotestuser1
+mail: mail.testuser1@{{ LDAP_DOMAIN }}
+preferredLanguage: de
+userPassword: otobotestuser1
+
+# example agent user otobotestuser2
+dn: cn=otobotestuser2,ou=devops,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: inetOrgPerson
+givenName: User
+cn: otobotestuser2
+sn: TestAgent 2
+uid: otobotestuser2
+mail: mail.testuser2@{{ LDAP_DOMAIN }}
+preferredLanguage: de
+userPassword: otobotestuser2
+
+# example admins LDAP group
+dn: cn=admins,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: top
+objectClass: groupOfNames
+cn: admins
+description: admin team
+member: cn=testadmin,ou=devops,{{ LDAP_BASE_DN }}
+
+# example agents LDAP group
+dn: cn=agents,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: top
+objectClass: groupOfNames
+cn: agents
+description: agent team
+member: cn=otobotestuser1,ou=devops,{{ LDAP_BASE_DN }}
+member: cn=otobotestuser2,ou=devops,{{ LDAP_BASE_DN }}
+member: cn=testadmin,ou=devops,{{ LDAP_BASE_DN }}

--- a/testing/openldap/lds
+++ b/testing/openldap/lds
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# examples
+
+# check connectivity
+ldapsearch -x -H ldap://localhost -b dc=otobotesting -D "cn=admin,dc=otobotesting" -w admin
+
+# list all entries
+ldapsearch -x -H ldap://localhost -b dc=otobotesting -s sub -D "cn=admin,dc=otobotesting" -w admin '(objectClass=*)' +
+
+# show a group
+ldapsearch -x -H ldap://localhost -b dc=otobotesting -s sub -D "cn=admin,dc=otobotesting" -w admin '(cn=admins)' dn member
+ldapsearch -x -H ldap://localhost -b dc=otobotesting -s sub -D "cn=admin,dc=otobotesting" -w admin '(cn=agents)' dn member
+
+# show a user
+ldapsearch -x -H ldap://localhost -b dc=otobotesting -s sub -D "cn=admin,dc=otobotesting" -w admin '(uid=testadmin)' uid memberOf
+ldapsearch -x -H ldap://localhost -b dc=otobotesting -s sub -D "cn=admin,dc=otobotesting" -w admin '(uid=otobotestuser1)' uid memberOf
+ldapsearch -x -H ldap://localhost -b dc=otobotesting -s sub -D "cn=admin,dc=otobotesting" -w admin '(uid=otobotestuser2)' uid memberOf


### PR DESCRIPTION
The base image changes from bitnamilegacy/openldap:latest to osixia/openldap:1.5.0

Adapting pathes and file names to match the existing setup. Keep the service name testing-openldap as this host name is checked in OpenLDAP.t.
Create the test agents otobotestuser1 and otobotestuser2 in order to stay compliant with the test cases in OpenLDAP.t.

The name of the LDAP adiministrator stays at 'admin'.

Expand the sample ldapsearch commands.